### PR TITLE
Fix Paladin circle color

### DIFF
--- a/mods/sp/rules/aircraft.yaml
+++ b/mods/sp/rules/aircraft.yaml
@@ -433,6 +433,12 @@ CERBERUS:
 		AttackType: Hover
 		FacingTolerance: 10
 		Voice: Attack
+	-Cloak@CLOAKGENERATOR:
+	WithRangeCircle:
+		Range: 4c0
+		Type: cloakgenerator
+		RenderOnGround: true
+		Color: 00FF7FCC
 	RenderSprites:
 		PlayerPalette: playertemperate
 	SpawnActorOnDeath:
@@ -443,11 +449,6 @@ CERBERUS:
 		EnableSound: cloak5.aud
 		DisableSound: cloak5.aud
 		AffectsParent: false
-	-Cloak@CLOAKGENERATOR:
-	WithRangeCircle:
-		Range: 4c0
-		Type: cloakgenerator
-		RenderOnGround: true
 	Explodes@Shrapnel:
 		Weapon: BigAircraftShrapnel
 		EmptyWeapon: BigAircraftShrapnel


### PR DESCRIPTION
Not going to add circle for Tyrant for player will mix it up and think it is the attack range.