### PR TITLE
(Balance will change!!!)AttackFollowFrontal that attack while moving like AttackAircraft

### DIFF
--- a/OpenRA.Mods.Sp/Activities/AttackFrontalFollowActivity.cs
+++ b/OpenRA.Mods.Sp/Activities/AttackFrontalFollowActivity.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.SP.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.SP.Activities
+{
+	public class AttackFrontalFollowActivity : Activity, IActivityNotifyStanceChanged
+	{
+		readonly AttackFollowFrontal attack;
+		readonly RevealsShroud[] revealsShroud;
+		readonly IMove move;
+		readonly bool forceAttack;
+		readonly Color? targetLineColor;
+		readonly IFacing facing;
+
+		Target target;
+		Target lastVisibleTarget;
+		bool useLastVisibleTarget;
+		WDist lastVisibleMaximumRange;
+		WDist lastVisibleMinimumRange;
+		BitSet<TargetableType> lastVisibleTargetTypes;
+		Player lastVisibleOwner;
+		bool wasMovingWithinRange;
+		bool hasTicked;
+
+		public AttackFrontalFollowActivity(Actor self, in Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		{
+			attack = self.Trait<AttackFollowFrontal>();
+			move = allowMove ? self.TraitOrDefault<IMove>() : null;
+			revealsShroud = self.TraitsImplementing<RevealsShroud>().ToArray();
+			facing = self.Trait<IFacing>();
+
+			this.target = target;
+			this.forceAttack = forceAttack;
+			this.targetLineColor = targetLineColor;
+
+			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
+			// Moving to any position (even if quite stale) is still better than immediately giving up
+			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
+				|| target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+			{
+				lastVisibleTarget = Target.FromPos(target.CenterPosition);
+				lastVisibleMaximumRange = attack.GetMaximumRangeVersusTarget(target);
+				lastVisibleMinimumRange = attack.GetMinimumRangeVersusTarget(target);
+
+				if (target.Type == TargetType.Actor)
+				{
+					lastVisibleOwner = target.Actor.Owner;
+					lastVisibleTargetTypes = target.Actor.GetEnabledTargetTypes();
+				}
+				else if (target.Type == TargetType.FrozenActor)
+				{
+					lastVisibleOwner = target.FrozenActor.Owner;
+					lastVisibleTargetTypes = target.FrozenActor.TargetTypes;
+				}
+			}
+		}
+
+		public override bool Tick(Actor self)
+		{
+			if (IsCanceling)
+				return true;
+
+			// Check that AttackFollow hasn't cancelled the target by modifying attack.Target
+			// Having both this and AttackFollow modify that field is a horrible hack.
+			if (hasTicked && attack.RequestedTarget.Type == TargetType.Invalid)
+				return true;
+
+			if (attack.IsTraitPaused)
+				return false;
+
+			target = target.Recalculate(self.Owner, out var targetIsHiddenActor);
+			attack.SetRequestedTarget(self, target, forceAttack);
+			hasTicked = true;
+
+			if (!targetIsHiddenActor && target.Type == TargetType.Actor)
+			{
+				lastVisibleTarget = Target.FromTargetPositions(target);
+				lastVisibleMaximumRange = attack.GetMaximumRangeVersusTarget(target);
+				lastVisibleMinimumRange = attack.GetMinimumRange();
+				lastVisibleOwner = target.Actor.Owner;
+				lastVisibleTargetTypes = target.Actor.GetEnabledTargetTypes();
+
+				var leeway = attack.Info.RangeMargin.Length;
+				if (leeway != 0 && move != null && target.Actor.Info.HasTraitInfo<IMoveInfo>())
+				{
+					var preferMinRange = Math.Min(lastVisibleMinimumRange.Length + leeway, lastVisibleMaximumRange.Length);
+					var preferMaxRange = Math.Max(lastVisibleMaximumRange.Length - leeway, lastVisibleMinimumRange.Length);
+					lastVisibleMaximumRange = new WDist((lastVisibleMaximumRange.Length - leeway).Clamp(preferMinRange, preferMaxRange));
+				}
+			}
+
+			// The target may become hidden in the same tick the AttackActivity constructor is called,
+			// causing lastVisible* to remain uninitialized.
+			// Fix the fallback values based on the frozen actor properties
+			else if (target.Type == TargetType.FrozenActor && !lastVisibleTarget.IsValidFor(self))
+			{
+				lastVisibleTarget = Target.FromTargetPositions(target);
+				lastVisibleMaximumRange = attack.GetMaximumRangeVersusTarget(target);
+				lastVisibleOwner = target.FrozenActor.Owner;
+				lastVisibleTargetTypes = target.FrozenActor.TargetTypes;
+			}
+
+			var maxRange = lastVisibleMaximumRange;
+			var minRange = lastVisibleMinimumRange;
+			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
+
+			// Most actors want to be able to see their target before shooting
+			if (target.Type == TargetType.FrozenActor && !attack.Info.TargetFrozenActors && !forceAttack)
+			{
+				var rs = revealsShroud
+					.Where(Exts.IsTraitEnabled)
+					.MaxByOrDefault(s => s.Range);
+
+				// Default to 2 cells if there are no active traits
+				var sightRange = rs != null ? rs.Range : WDist.FromCells(2);
+				if (sightRange < maxRange)
+					maxRange = sightRange;
+			}
+
+			// If we are ticking again after previously sequencing a MoveWithRange then that move must have completed
+			// Either we are in range and can see the target, or we've lost track of it and should give up
+			if (wasMovingWithinRange && targetIsHiddenActor)
+				return true;
+
+			// Target is hidden or dead, and we don't have a fallback position to move towards
+			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
+				return true;
+
+			var pos = self.CenterPosition;
+			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
+
+			// We've reached the required range - if the target is visible and valid then we wait
+			// otherwise if it is hidden or dead we give up
+			if (checkTarget.IsInRange(pos, maxRange) && !checkTarget.IsInRange(pos, minRange))
+			{
+				var extraTurning = attack.Info.MustFaceTarget ? WAngle.Zero : attack.Info.FacingTolerance;
+				if (!attack.TargetInFiringArc(self, checkTarget, extraTurning))
+				{
+					var desiredFacing = (attack.GetTargetPosition(pos, checkTarget) - pos).Yaw;
+					facing.Facing = Util.TickFacing(facing.Facing, desiredFacing, facing.TurnSpeed);
+				}
+
+				if (useLastVisibleTarget)
+					return true;
+
+				return false;
+			}
+
+			// We can't move into range, so give up
+			if (move == null || maxRange == WDist.Zero || maxRange < minRange)
+				return true;
+
+			wasMovingWithinRange = true;
+			QueueChild(move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition));
+			return false;
+		}
+
+		protected override void OnLastRun(Actor self)
+		{
+			// Cancel the requested target, but keep firing on it while in range
+			attack.ClearRequestedTarget();
+		}
+
+		void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)
+		{
+			// Cancel non-forced targets when switching to a more restrictive stance if they are no longer valid for auto-targeting
+			if (newStance > oldStance || forceAttack)
+				return;
+
+			// If lastVisibleTarget is invalid we could never view the target in the first place, so we just drop it here too
+			if (!lastVisibleTarget.IsValidFor(self) || !autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
+				attack.ClearRequestedTarget();
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor != null)
+				yield return new TargetLineNode(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value);
+		}
+	}
+}

--- a/OpenRA.Mods.Sp/Traits/AttackFollowFrontal.cs
+++ b/OpenRA.Mods.Sp/Traits/AttackFollowFrontal.cs
@@ -1,0 +1,203 @@
+﻿using OpenRA.Activities;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.SP.Activities;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.SP.Traits
+{
+	public class AttackFollowFrontalInfo : AttackFollowInfo
+	{
+		[Desc("Actor will turn directly to target regardless the FacingTolerance to catch its target in full fire angle.")]
+		public readonly bool MustFaceTarget = false;
+
+		public override object Create(ActorInitializer init) { return new AttackFollowFrontal(init.Self, this); }
+	}
+
+	public class AttackFollowFrontal : AttackBase, INotifyOwnerChanged, IDisableAutoTarget, INotifyStanceChanged
+	{
+		public new readonly AttackFollowFrontalInfo Info;
+		public Target RequestedTarget { get; private set; }
+		public Target OpportunityTarget { get; private set; }
+
+		Mobile mobile;
+		AutoTarget autoTarget;
+		bool requestedForceAttack;
+		Activity requestedTargetPresetForActivity;
+		bool opportunityForceAttack;
+		bool opportunityTargetIsPersistentTarget;
+
+		public void SetRequestedTarget(Actor self, in Target target, bool isForceAttack = false)
+		{
+			RequestedTarget = target;
+			requestedForceAttack = isForceAttack;
+			requestedTargetPresetForActivity = null;
+		}
+
+		public void ClearRequestedTarget()
+		{
+			if (Info.PersistentTargeting)
+			{
+				OpportunityTarget = RequestedTarget;
+				opportunityForceAttack = requestedForceAttack;
+				opportunityTargetIsPersistentTarget = true;
+			}
+
+			RequestedTarget = Target.Invalid;
+			requestedTargetPresetForActivity = null;
+		}
+
+		public AttackFollowFrontal(Actor self, AttackFollowFrontalInfo info)
+			: base(self, info)
+		{
+			Info = info;
+		}
+
+		protected override void Created(Actor self)
+		{
+			mobile = self.TraitOrDefault<Mobile>();
+			autoTarget = self.TraitOrDefault<AutoTarget>();
+			base.Created(self);
+		}
+
+		protected bool CanAimAtTarget(Actor self, in Target target, bool forceAttack)
+		{
+			if (target.Type == TargetType.Actor && !target.Actor.CanBeViewedByPlayer(self.Owner))
+				return false;
+
+			if (target.Type == TargetType.FrozenActor && !target.FrozenActor.IsValid)
+				return false;
+
+			var pos = self.CenterPosition;
+			var armaments = ChooseArmamentsForTarget(target, forceAttack);
+			foreach (var a in armaments)
+				if (target.IsInRange(pos, a.MaxRange()) && (a.Weapon.MinRange == WDist.Zero || !target.IsInRange(pos, a.Weapon.MinRange)))
+					if (TargetInFiringArc(self, target, Info.FacingTolerance))
+						return true;
+
+			return false;
+		}
+
+		protected override void Tick(Actor self)
+		{
+			if (IsTraitDisabled)
+			{
+				RequestedTarget = OpportunityTarget = Target.Invalid;
+				opportunityTargetIsPersistentTarget = false;
+			}
+
+			if (requestedTargetPresetForActivity != null)
+			{
+				// RequestedTarget was set by OnQueueAttackActivity in preparation for a queued activity
+				// requestedTargetPresetForActivity will be cleared once the activity starts running and calls UpdateRequestedTarget
+				if (self.CurrentActivity != null && self.CurrentActivity.NextActivity == requestedTargetPresetForActivity)
+				{
+					RequestedTarget = RequestedTarget.Recalculate(self.Owner, out _);
+				}
+
+				// Requested activity has been canceled
+				else
+					ClearRequestedTarget();
+			}
+
+			// Can't fire on anything
+			if (mobile != null && !mobile.CanInteractWithGroundLayer(self))
+				return;
+
+			if (RequestedTarget.Type != TargetType.Invalid)
+			{
+				IsAiming = CanAimAtTarget(self, RequestedTarget, requestedForceAttack);
+				if (IsAiming)
+					DoAttack(self, RequestedTarget);
+			}
+			else
+			{
+				IsAiming = false;
+
+				if (OpportunityTarget.Type != TargetType.Invalid)
+					IsAiming = CanAimAtTarget(self, OpportunityTarget, opportunityForceAttack);
+
+				if (!IsAiming && Info.OpportunityFire && autoTarget != null &&
+					!autoTarget.IsTraitDisabled && autoTarget.Stance >= UnitStance.Defend)
+				{
+					OpportunityTarget = autoTarget.ScanForTarget(self, false, false);
+					opportunityForceAttack = false;
+					opportunityTargetIsPersistentTarget = false;
+
+					if (OpportunityTarget.Type != TargetType.Invalid)
+						IsAiming = CanAimAtTarget(self, OpportunityTarget, opportunityForceAttack);
+				}
+
+				if (IsAiming)
+					DoAttack(self, OpportunityTarget);
+			}
+
+			base.Tick(self);
+		}
+
+		public override Activity GetAttackActivity(Actor self, AttackSource source, in Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		{
+			return new AttackFrontalFollowActivity(self, newTarget, allowMove, forceAttack, targetLineColor);
+		}
+
+		public override void OnResolveAttackOrder(Actor self, Activity activity, in Target target, bool queued, bool forceAttack)
+		{
+			// We can improve responsiveness for turreted actors by preempting
+			// the last order (usually a move) and setting the target immediately
+			if (!queued)
+			{
+				RequestedTarget = target;
+				requestedForceAttack = forceAttack;
+				requestedTargetPresetForActivity = activity;
+			}
+		}
+
+		public override void OnStopOrder(Actor self)
+		{
+			RequestedTarget = OpportunityTarget = Target.Invalid;
+			opportunityTargetIsPersistentTarget = false;
+			base.OnStopOrder(self);
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			RequestedTarget = OpportunityTarget = Target.Invalid;
+			opportunityTargetIsPersistentTarget = false;
+		}
+
+		bool IDisableAutoTarget.DisableAutoTarget(Actor self)
+		{
+			return RequestedTarget.Type != TargetType.Invalid ||
+				(opportunityTargetIsPersistentTarget && OpportunityTarget.Type != TargetType.Invalid);
+		}
+
+		void INotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)
+		{
+			// Cancel opportunity targets when switching to a more restrictive stance if they are no longer valid for auto-targeting
+			if (newStance > oldStance || opportunityForceAttack)
+				return;
+
+			if (OpportunityTarget.Type == TargetType.Actor)
+			{
+				var a = OpportunityTarget.Actor;
+				if (!autoTarget.HasValidTargetPriority(self, a.Owner, a.GetEnabledTargetTypes()))
+					OpportunityTarget = Target.Invalid;
+			}
+			else if (OpportunityTarget.Type == TargetType.FrozenActor)
+			{
+				var fa = OpportunityTarget.FrozenActor;
+				if (!autoTarget.HasValidTargetPriority(self, fa.Owner, fa.TargetTypes))
+					OpportunityTarget = Target.Invalid;
+			}
+		}
+
+		protected override bool CanAttack(Actor self, in Target target)
+		{
+			if (!base.CanAttack(self, target))
+				return false;
+
+			return TargetInFiringArc(self, target, Info.FacingTolerance);
+		}
+	}
+}

--- a/mods/sp/rules/infantry.yaml
+++ b/mods/sp/rules/infantry.yaml
@@ -989,10 +989,15 @@ MUTFIEND:
 		Weapon: GFiendShardAA
 		ReloadingCondition: reload-air
 		PauseOnCondition: WebDisable || reload-ground
-	AttackFrontal:
+	#AttackFrontal:
+	#	Voice: Attack
+	#	Armaments: OnFoot
+	#	FacingTolerance: 2
+	AttackFollowFrontal:
 		Voice: Attack
 		Armaments: OnFoot
-		FacingTolerance: 2
+		FacingTolerance: 64
+		MustFaceTarget: true
 	-TakeCover:
 	-WithDeathAnimation@tib:
 	-SpawnActorOnDeath@FLAMEGUY:

--- a/mods/sp/rules/vehicles.yaml
+++ b/mods/sp/rules/vehicles.yaml
@@ -24,10 +24,11 @@ SMECH:
 		HP: 17500
 	Armor:
 		Type: Light
-	AttackFrontal:
+	AttackFollowFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
-		FacingTolerance: 2
+		FacingTolerance: 64
+		MustFaceTarget: true
 	AutoTarget:
 	Voiced:
 		VoiceSet: Mech
@@ -260,10 +261,16 @@ JUG:
 		Locomotor: InfantryCrusherVehicle
 	Health:
 		HP: 25000
-	AttackFrontal:
+	#AttackFrontal:
+	#	Voice: Attack
+	#	Armaments: primary, secondary
+	#	PauseOnCondition: empdisable
+	#	TargetFrozenActors: true
+	AttackFollowFrontal:
 		Voice: Attack
-		Armaments: primary, secondary
 		PauseOnCondition: empdisable
+		FacingTolerance: 64
+		MustFaceTarget: true
 		TargetFrozenActors: true
 	AutoTarget:
 		ScanRadius: 16
@@ -983,9 +990,14 @@ ATTACKBIKE:
 		ReloadingCondition: reload-air
 		PauseOnCondition: empdisable || reload-ground
 		LocalYaw: 100, -100
-	AttackFrontal:
+	#AttackFrontal:
+	#	PauseOnCondition: empdisable
+	#	FacingTolerance: 20
+	AttackFollowFrontal:
+		Voice: Attack
 		PauseOnCondition: empdisable
-		FacingTolerance: 20
+		FacingTolerance: 64
+		MustFaceTarget: true
 
 TTNK:
 	Inherits: ^Tank
@@ -1076,10 +1088,16 @@ TTNK:
 		Sequence: deployed
 		Name: deployed
 		RequiresCondition: !undeployed
-	AttackFrontal:
+	#AttackFrontal:
+	#	Voice: Attack
+	#	RequiresCondition: undeployed
+	#	PauseOnCondition: empdisable
+	AttackFollowFrontal:
 		Voice: Attack
-		RequiresCondition: undeployed
 		PauseOnCondition: empdisable
+		RequiresCondition: undeployed
+		FacingTolerance: 64
+		MustFaceTarget: true
 	Turreted:
 		TurnSpeed: 40
 		Turret: deployed
@@ -1097,7 +1115,7 @@ TTNK:
 	ExternalCondition@RefineryLock:
 		Condition: RefineryLock
 	AutoDeployer@AI:
-		RequiresCondition: AImicroManage && !deployed
+		RequiresCondition: AImicroManage
 		DeployChance: 100
 		DeployTrigger: Attack
 		DeployTicks: 5
@@ -1131,6 +1149,8 @@ TICKHOLOGRAM:
 		TargetTypes: Ground, Vehicle, Summoned
 	Armament@PRIMARY:
 		Weapon: HologramTick90mm
+		LocalOffset: 350,-0,500
+		MuzzleSequence: muzzle
 	WithFacingSpriteBody:
 		Sequence: idle
 		RequiresCondition: !inside-tunnel
@@ -1148,6 +1168,8 @@ TICKHOLOGRAM:
 			EnergyDeath: evaporate
 			ExplosionDeath: evaporate
 	AttackFrontal:
+		Voice: Attack
+		PauseOnCondition: empdisable
 	AutoTarget:
 		ScanRadius: 7
 		InitialStance: AttackAnything
@@ -1841,6 +1863,11 @@ WOLF:
 	Mobile:
 		Speed: 105
 		Locomotor: TibVeCritter
+	AttackFollowFrontal:
+		Voice: Attack
+		FacingTolerance: 64
+		MustFaceTarget: true
+	-AttackFrontal:
 
 MRLS:
 	Inherits: ^Tank
@@ -1957,8 +1984,6 @@ HVRTRUK3:
 	Voiced:
 		VoiceSet: DemoTruck
 		Volume: 3
-	# Repairable:
-	#	Voice: Repair
 	Mobile:
 		TurnSpeed: 40
 		CanMoveBackward: true
@@ -2344,10 +2369,15 @@ REAPERCAB:
 		DeathSequencePalette: player
 		DeathPaletteIsPlayerPalette: true
 		UseDeathTypeSuffix: false
-	AttackFrontal:
+	#AttackFrontal:
+	#	Voice: Attack
+	#	PauseOnCondition: empdisable
+	#	FacingTolerance: 2
+	AttackFollowFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
-		FacingTolerance: 2
+		FacingTolerance: 64
+		MustFaceTarget: true
 	WithInfantryBody:
 		-DefaultAttackSequence:
 	BodyOrientation:
@@ -2504,8 +2534,13 @@ REPAIRVEHICLE:
 		LocalOffset: 200,0,950
 		MuzzleSequence: muzzle
 		MuzzlePalette: player
-	AttackFrontal:
+	#AttackFrontal:
+	#	Voice: Attack
+	AttackFollowFrontal:
 		Voice: Attack
+		PauseOnCondition: empdisable
+		FacingTolerance: 64
+		MustFaceTarget: true
 	Voiced:
 		VoiceSet: Limpet
 	WithFacingSpriteBody:
@@ -2818,9 +2853,14 @@ CORRUPTOR:
 		Locomotor: InfantryCrusherVehicle
 	Health:
 		HP: 30000
-	AttackFrontal:
+	#AttackFrontal:
+	#	Voice: Attack
+	#	PauseOnCondition: empdisable
+	AttackFollowFrontal:
 		Voice: Attack
 		PauseOnCondition: empdisable
+		FacingTolerance: 64
+		MustFaceTarget: true
 	AutoTarget:
 	Armament@PRIMARY:
 		Weapon: CorruptorAcid
@@ -2976,9 +3016,14 @@ SCRGLYDER2:
 		RecoilRecovery: 25
 		LocalOffset: -250,0,1300
 		PauseOnCondition: empdisable || !cannonready
-	AttackFrontal:
+	#AttackFrontal:
+	#	PauseOnCondition: empdisable
+	#	FacingTolerance: 5
+	AttackFollowFrontal:
+		Voice: Attack
 		PauseOnCondition: empdisable
-		FacingTolerance: 5
+		FacingTolerance: 64
+		MustFaceTarget: true
 	Armament@AITransformDummyWeapon:
 		RequiresCondition: AImicroManage
 		Weapon: AIGlyder2AimingDummyWeapon


### PR DESCRIPTION
Make some T1/T2 unit can attack while moving (mainly light vehicle) which is like air units use `AttackAircraft`

This will be a life improve like in cnc3, which also affects balance due to those can attack front while moving will do better than before in face to face assualt

![mfshowcase-preview](https://user-images.githubusercontent.com/13763394/159161127-1a99b6ba-6845-4c39-be26-30c67bba7799.gif)

You can use [attackfollowfrontal](https://github.com/ABrandau/Shattered-Paradise-SDK/tree/attackfollowfrontal) branch in this repo to test